### PR TITLE
@ #15 | should update _id to use key name instead of key index: bug fix for _id_deprecated of chef provisioner

### DIFF
--- a/lib/teracy-dev-v05-compat.rb
+++ b/lib/teracy-dev-v05-compat.rb
@@ -2,10 +2,14 @@ require 'teracy-dev'
 
 require_relative 'teracy-dev-v05-compat/config/gatling_rsync_recovery'
 require_relative 'teracy-dev-v05-compat/processors/multiple_essential_support'
+require_relative 'teracy-dev-v05-compat/processors/provisioner_id_deprecated_removal'
+
 module TeracyDevV05Compat
 
   def self.init
     TeracyDev.register_processor(Processors::MultipleEssentialSupport.new)
+    TeracyDev.register_processor(Processors::ProvisionerIdDeprecatedRemoval.new)
+
     TeracyDev.register_configurator(TeracyDevV05Compat::Config::GatlingRsyncRecovery.new)
   end
 

--- a/lib/teracy-dev-v05-compat/processors/provisioner_id_deprecated_removal.rb
+++ b/lib/teracy-dev-v05-compat/processors/provisioner_id_deprecated_removal.rb
@@ -1,0 +1,30 @@
+require 'teracy-dev/processors/processor'
+
+module TeracyDevV05Compat
+  module Processors
+    # a workaround to fix the following problem:
+    # $ vagrant up
+    # Bringing machine 'teracy-dev.local' up with 'virtualbox' provider...
+    # There are errors in the configuration of this machine. Please fix
+    # the following errors and try again:
+    # chef solo provisioner:
+    # * The following settings shouldn't exist: _id_deprecated
+    #
+    # @see: https://github.com/teracyhq-incubator/teracy-dev-core/issues/58
+    class ProvisionerIdDeprecatedRemoval < TeracyDev::Processors::Processor
+
+      def process(settings)
+        settings['nodes'].each_with_index do |node, node_idx|
+          node['provisioners'].each_with_index do |provisioner, idx|
+            if !provisioner['_id_deprecated'].nil?
+              provisioner.delete('_id_deprecated')
+              node['provisioners'][idx] = provisioner
+              settings['nodes'][node_idx] = node
+            end
+          end unless node['provisioners'].nil?
+        end unless settings['nodes'].nil?
+        return settings
+      end
+    end
+  end
+end


### PR DESCRIPTION
connect #15 